### PR TITLE
changed method of getting collection name of Genealogie Online publication

### DIFF
--- a/Acoose.Centurial.Package/nl/GenealogieOnline.cs
+++ b/Acoose.Centurial.Package/nl/GenealogieOnline.cs
@@ -22,11 +22,7 @@ namespace Acoose.Centurial.Package.nl
             var collectionUrl = new Uri(context.Url).AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
 
             // collection name
-            var collectionName = context.Html.SelectSingleNode("//div[contains(@class, 'panel-body')]/a")?.InnerText;
-            if (string.IsNullOrWhiteSpace(collectionName))
-            {
-                collectionName = context.Html.SelectSingleNode("//p[starts-with(., 'De publicatie') and contains(., 'is samengesteld door')]//b")?.InnerText;
-            }
+            var collectionName = context.GetMetaTag("collection");
 
             // page title
             var pageTitle = context.GetPageTitle().Split('»').FirstOrDefault()?.Trim();


### PR DESCRIPTION
Genealogie Online now emits the name of the publication in a separate meta tag called "collection". This meta tag is language independant and available on all pages which are part of the publication. 